### PR TITLE
DB定義にお気に入りに関係するものの追加

### DIFF
--- a/documents/db/README.md
+++ b/documents/db/README.md
@@ -194,7 +194,7 @@ MySQL
 			ユーザID
 		</td>
 		<td>
-			userId
+			user_id
 		</td>
 		<td>
 			CHAR(32)
@@ -204,6 +204,98 @@ MySQL
 		</td>
 		<td>
 			user.id
+		</td>
+	</tr>
+</table>
+
+<table>
+	<tr>
+		<th colspan="5">
+			favorite
+		</th>
+	</tr>
+	<tr>
+		<td>
+			お気に入りID
+		</td>
+		<td>
+			id
+		</td>
+		<td>
+			CHAR(32)
+		</td>
+		<td>
+			PK
+		</td>
+		<td>
+			バックエンドでUUID生成
+		</td>
+	</tr>
+	<tr>
+		<td>
+			登録日時
+		</td>
+		<td>
+			created_at
+		</td>
+		<td>
+			TIMESTAMP
+		</td>
+		<td>
+			NN
+		</td>
+		<td>
+			JSTで格納する
+		</td>
+	</tr>
+	<tr>
+		<td>
+			更新日時
+		</td>
+		<td>
+			updated_at
+		</td>
+		<td>
+			TIMESTAMP
+		</td>
+		<td>
+			NN
+		</td>
+		<td>
+			JSTで格納する
+		</td>
+	</tr>
+	<tr>
+		<td>
+			ユーザID
+		</td>
+		<td>
+			user_id
+		</td>
+		<td>
+			CHAR(32)
+		</td>
+		<td>
+			FK
+		</td>
+		<td>
+			user.id
+		</td>
+	</tr>
+		<td>
+			メッセージID
+		</td>
+		<td>
+			message_id
+		</td>
+		<td>
+			CHAR(32)
+		</td>
+		<td>
+			FK
+		</td>
+		<td>
+			message.id
 		</td>
 	</tr>
 </table>

--- a/documents/db/README.md
+++ b/documents/db/README.md
@@ -7,7 +7,7 @@ MySQL
 <table>
 	<tr>
 		<th colspan="5">
-			user
+			users
 		</th>
 	</tr>
 	<tr>
@@ -118,7 +118,7 @@ MySQL
 <table>
 	<tr>
 		<th colspan="5">
-			message
+			messages
 		</th>
 	</tr>
 	<tr>
@@ -203,7 +203,7 @@ MySQL
 			FK
 		</td>
 		<td>
-			user.id
+			users.id
 		</td>
 	</tr>
 </table>
@@ -211,7 +211,7 @@ MySQL
 <table>
 	<tr>
 		<th colspan="5">
-			favorite
+			favorites
 		</th>
 	</tr>
 	<tr>
@@ -279,7 +279,7 @@ MySQL
 			FK
 		</td>
 		<td>
-			user.id
+			users.id
 		</td>
 	</tr>
 		<td>
@@ -295,7 +295,7 @@ MySQL
 			FK
 		</td>
 		<td>
-			message.id
+			messages.id
 		</td>
 	</tr>
 </table>

--- a/documents/db/README.md
+++ b/documents/db/README.md
@@ -7,7 +7,7 @@ MySQL
 <table>
 	<tr>
 		<th colspan="5">
-			User
+			user
 		</th>
 	</tr>
 	<tr>
@@ -118,7 +118,7 @@ MySQL
 <table>
 	<tr>
 		<th colspan="5">
-			Message
+			message
 		</th>
 	</tr>
 	<tr>
@@ -203,7 +203,7 @@ MySQL
 			FK
 		</td>
 		<td>
-			User.id
+			user.id
 		</td>
 	</tr>
 </table>

--- a/documents/db/erd.md
+++ b/documents/db/erd.md
@@ -1,7 +1,7 @@
 ```mermaid
 erDiagram
 
-  User {
+  user {
     String id PK 
     String name  
     String email  
@@ -11,12 +11,19 @@ erDiagram
     }
   
 
-  Message {
+  message {
     String id PK 
     String body  
     DateTime created_at  
     DateTime updated_at  
     }
   
-    Message o{--|o User : "User"
+
+  favorite {
+    String id PK 
+    }
+  
+    message o{--|o user : "User"
+    favorite o{--|o user : "User"
+    favorite o{--|o message : "Message"
 ```

--- a/documents/db/erd.md
+++ b/documents/db/erd.md
@@ -1,7 +1,7 @@
 ```mermaid
 erDiagram
 
-  user {
+  users {
     String id PK 
     String name  
     String email  
@@ -11,7 +11,7 @@ erDiagram
     }
   
 
-  message {
+  messages {
     String id PK 
     String body  
     DateTime created_at  
@@ -19,11 +19,13 @@ erDiagram
     }
   
 
-  favorite {
+  favorites {
     String id PK 
+    DateTime created_at  
+    DateTime updated_at  
     }
   
-    message o{--|o user : "User"
-    favorite o{--|o user : "User"
-    favorite o{--|o message : "Message"
+    messages o{--|o users : "users"
+    favorites o{--|o users : "users"
+    favorites o{--|o messages : "messages"
 ```

--- a/utils/prisma/schema.prisma
+++ b/utils/prisma/schema.prisma
@@ -1,7 +1,8 @@
 generator erd {
   provider = "prisma-erd-generator"
   output   = "../out/erd.md"
-  theme    = "forest"
+  theme    = "forest" // 効いてないっぽい?
+  // TODO: FK表現できないか
 }
 
 datasource db {
@@ -9,31 +10,33 @@ datasource db {
   url      = "hoge"
 }
 
-model user {
-  id         String     @id @db.Char(32) /// バックエンドでUUID生成
-  name       String     @db.VarChar(64) /// 日本語英語問わず64、登録なしはできない
-  email      String     @unique @db.VarChar(255) /// もしUQつけないならIndex貼ったほうがいい
-  password   String     @db.VarChar(255) /// 8 文字以上 32 文字以下(ハッシュ化した後の文字数で決めるのが良さそう)
-  created_at DateTime   @default(now()) @db.Timestamp()
-  updated_at DateTime   @default(now()) @db.Timestamp()
-  posts      message[]
-  favorite   favorite[]
+model users {
+  id         String      @id @db.Char(32) /// バックエンドでUUID生成
+  name       String      @db.VarChar(64) /// 日本語英語問わず64、登録なしはできない
+  email      String      @unique @db.VarChar(255) /// もしUQつけないならIndex貼ったほうがいい
+  password   String      @db.VarChar(255) /// 8 文字以上 32 文字以下(ハッシュ化した後の文字数で決めるのが良さそう)
+  created_at DateTime    @default(now()) @db.Timestamp()
+  updated_at DateTime    @default(now()) @db.Timestamp()
+  posts      messages[]
+  favorites  favorites[]
 }
 
-model message {
-  id         String     @id @db.Char(32) /// バックエンドでUUID生成
-  body       String     @db.Text /// 日本語で最大140文字
-  created_at DateTime   @default(now()) @db.Timestamp() /// Current TimeStamp
-  updated_at DateTime   @default(now()) @db.Timestamp() /// Current TimeStamp
-  User       user?      @relation(fields: [user_id], references: [id])
+model messages {
+  id         String      @id @db.Char(32) /// バックエンドでUUID生成
+  body       String      @db.Text /// 日本語で最大140文字
+  created_at DateTime    @default(now()) @db.Timestamp() /// Current TimeStamp
+  updated_at DateTime    @default(now()) @db.Timestamp() /// Current TimeStamp
+  users      users?      @relation(fields: [user_id], references: [id])
   user_id    String
-  favorite   favorite[]
+  favorites  favorites[]
 }
 
-model favorite {
-  id         String   @id @db.Char(32) /// バックエンドでUUID生成
-  User       user?    @relation(fields: [user_id], references: [id])
+model favorites {
+  id         String    @id @db.Char(32) /// バックエンドでUUID生成
+  created_at DateTime  @default(now()) @db.Timestamp() /// Current TimeStamp
+  updated_at DateTime  @default(now()) @db.Timestamp() /// Current TimeStamp
+  users      users?    @relation(fields: [user_id], references: [id])
   user_id    String
-  Message    message? @relation(fields: [message_id], references: [id])
+  messages   messages? @relation(fields: [message_id], references: [id])
   message_id String
 }

--- a/utils/prisma/schema.prisma
+++ b/utils/prisma/schema.prisma
@@ -9,21 +9,31 @@ datasource db {
   url      = "hoge"
 }
 
-model User {
-  id         String    @id @db.Char(32) /// バックエンドでUUID生成
-  name       String    @db.VarChar(64) /// 日本語英語問わず64、登録なしはできない
-  email      String    @unique @db.VarChar(255) /// もしUQつけないならIndex貼ったほうがいい
-  password   String    @db.VarChar(255) /// 8 文字以上 32 文字以下(ハッシュ化した後の文字数で決めるのが良さそう)
-  created_at DateTime  @default(now()) @db.Timestamp()
-  updated_at DateTime  @default(now()) @db.Timestamp()
-  posts      Message[]
+model user {
+  id         String     @id @db.Char(32) /// バックエンドでUUID生成
+  name       String     @db.VarChar(64) /// 日本語英語問わず64、登録なしはできない
+  email      String     @unique @db.VarChar(255) /// もしUQつけないならIndex貼ったほうがいい
+  password   String     @db.VarChar(255) /// 8 文字以上 32 文字以下(ハッシュ化した後の文字数で決めるのが良さそう)
+  created_at DateTime   @default(now()) @db.Timestamp()
+  updated_at DateTime   @default(now()) @db.Timestamp()
+  posts      message[]
+  favorite   favorite[]
 }
 
-model Message {
-  id         String   @id @db.Char(32) /// バックエンドでUUID生成
-  body       String   @db.Text /// 日本語で最大140文字
-  created_at DateTime @default(now()) @db.Timestamp() /// Current TimeStamp
-  updated_at DateTime @default(now()) @db.Timestamp() /// Current TimeStamp
-  User       User?    @relation(fields: [user_id], references: [id])
+model message {
+  id         String     @id @db.Char(32) /// バックエンドでUUID生成
+  body       String     @db.Text /// 日本語で最大140文字
+  created_at DateTime   @default(now()) @db.Timestamp() /// Current TimeStamp
+  updated_at DateTime   @default(now()) @db.Timestamp() /// Current TimeStamp
+  User       user?      @relation(fields: [user_id], references: [id])
   user_id    String
+  favorite   favorite[]
+}
+
+model favorite {
+  id         String   @id @db.Char(32) /// バックエンドでUUID生成
+  User       user?    @relation(fields: [user_id], references: [id])
+  user_id    String
+  Message    message? @relation(fields: [message_id], references: [id])
+  message_id String
 }


### PR DESCRIPTION
# やったこと

- お気に入りに関係するテーブルの追加
<img width="829" alt="image" src="https://user-images.githubusercontent.com/49822810/212266053-a8ee9f27-1a10-4f75-8ebf-ecf775319ddd.png">

<img width="311" alt="image" src="https://user-images.githubusercontent.com/49822810/212266187-81fbe566-6613-48bc-8cf4-45af824943c7.png">

# やらないこと

- なし

# できるようになること

- メッセージにお気に入りしたことをDBに保存できるように

# できなくなること

- なし

# 動作確認

- どのような動作確認を行ったのか？ 結果はどうか？（必要があればスクリーンショットを貼り付け）

# レビュワーへの参考情報

- お気に入り数のカウントについて、messageテーブルに追加してそちらから読み出す方向にしたほうがいいでしょうか？（必要なら修正します

# チェックリスト（全てにチェックを入れた上でレビュー依頼）

- [x] セルフレビューを行なった。
- [x] コメントが必要な箇所を洗い出し、書き残した。
- [x] 変更部分に対応するドキュメントを洗い出し、修正した。
- [x] 設計・コーディング規則に違反している箇所がないことを確認した。
- [x] スペルミスがないことを確認した。
