### PR TITLE
メッセージ投稿系テスト

### DIFF
--- a/packages/backend/tests/Feature/Http/Controllers/CreateMessageMessagesControllerTest.php
+++ b/packages/backend/tests/Feature/Http/Controllers/CreateMessageMessagesControllerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use App\Models\Message;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Symfony\Component\HttpFoundation\Response as ResponseAlias;
+use Tests\TestCase;
+
+class CreateMessageMessagesControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * メッセージ投稿できるか
+     *
+     * @return void
+     */
+    public function testMessageCreate(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $this->assertDatabaseCount('messages', 0);
+        $body = 'test';
+
+        $response = $this->post('/api/v1/messages', [
+            'body' => $body,
+        ]);
+        $response->assertStatus(ResponseAlias::HTTP_CREATED);
+
+        $this->assertDatabaseCount('messages', 1);
+        $user = Message::first();
+        $this->assertEquals($body, $user->body);
+    }
+}

--- a/packages/backend/tests/Unit/Requests/MessageCreateRequestTest.php
+++ b/packages/backend/tests/Unit/Requests/MessageCreateRequestTest.php
@@ -20,45 +20,36 @@ class MessageCreateRequestTest extends TestCase
     }
 
     /**
-     * バリデーションテスト
+     * バリデーションテスト(異常系)
      *
-     * @dataProvider signupUsersArgsValidationDataProvider
+     * @dataProvider signupUsersArgsValidationInvalidDataProvider
      *
      * @param  array  $data
      * @param  array  $errors
-     * @param  bool  $expect
      * @return void
      */
-    public function testSignupUsersArgsValidation(array $data, array $errors, bool $expect): void
+    public function testSignupUsersArgsValidationFailed(array $data, array $errors): void
     {
         $rules = $this->request->rules();
         $validator = Validator::make($data, $rules);
 
         $result = $validator->passes();
 
-        $this->assertEquals($expect, $result);
+        $this->assertEquals(false, $result);
         $this->assertEquals($errors, $validator->errors()->toArray());
     }
 
     /**
-     * テストに渡すデータ
+     * 異常系テストに渡すデータ
      */
-    public function signupUsersArgsValidationDataProvider(): array
+    public function signupUsersArgsValidationInvalidDataProvider(): array
     {
         return [
-            '正常系' => [
-                'data' => [
-                    'body' => 'test',
-                ],
-                'errors' => [],
-                'expect' => true,
-            ],
             'フィールドが空' => [
                 'data' => [],
                 'errors' => [
                     'body' => ['The body field is required.'],
                 ],
-                'expect' => false,
             ],
             '文字数が多すぎる' => [
                 'data' => [
@@ -67,7 +58,6 @@ class MessageCreateRequestTest extends TestCase
                 'errors' => [
                     'body' => ['The body must not be greater than 140 characters.'],
                 ],
-                'expect' => false,
             ],
             //            'Edge: 絵文字でも正しくカウントできる' => [
             //                'data' => [
@@ -77,6 +67,38 @@ class MessageCreateRequestTest extends TestCase
             //                    'body' => ['The body must not be greater than 140 characters.'],
             //                ],
             //            ],
+        ];
+    }
+
+    /**
+     * バリデーションテスト(正常系)
+     *
+     * @dataProvider signupUsersArgsValidationValidDataProvider
+     *
+     * @param  array  $data
+     * @return void
+     */
+    public function testSignupUsersArgsValidationSuccess(array $data): void
+    {
+        $rules = $this->request->rules();
+        $validator = Validator::make($data, $rules);
+
+        $result = $validator->passes();
+
+        $this->assertEquals(true, $result);
+    }
+
+    /**
+     * 正常系テストに渡すデータ
+     */
+    public function signupUsersArgsValidationValidDataProvider(): array
+    {
+        return [
+            '正常系' => [
+                'data' => [
+                    'body' => 'test',
+                ],
+            ],
         ];
     }
 }

--- a/packages/backend/tests/Unit/Requests/MessageCreateRequestTest.php
+++ b/packages/backend/tests/Unit/Requests/MessageCreateRequestTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace tests\Unit\Requests;
+
+use App\Http\Requests\MessageCreateRequest;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Validator;
+use Tests\TestCase;
+
+class MessageCreateRequestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected MessageCreateRequest $request;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->request = new MessageCreateRequest();
+    }
+
+    public function testInstanceOf(): void
+    {
+        $this->assertInstanceOf(MessageCreateRequest::class, $this->request);
+    }
+
+    /**
+     * バリデーションテスト
+     *
+     * @dataProvider signupUsersArgsValidationDataProvider
+     *
+     * @param  array  $data
+     * @param  array  $errors
+     * @return void
+     */
+    public function testSignupUsersArgsValidation(array $data, array $errors): void
+    {
+        $rules = $this->request->rules();
+        $validator = Validator::make($data, $rules);
+
+        $result = $validator->passes();
+
+        $this->assertEquals(false, $result);
+        $this->assertEquals($errors, $validator->errors()->toArray());
+    }
+
+    /**
+     * テストに渡すデータ
+     */
+    public function signupUsersArgsValidationDataProvider(): array
+    {
+        return [
+            'フィールドが空' => [
+                'data' => [],
+                'errors' => [
+                    'body' => ['The body field is required.'],
+                ],
+            ],
+            '文字数が多すぎる' => [
+                'data' => [
+                    'body' => str_repeat('a', 141),
+                ],
+                'errors' => [
+                    'body' => ['The body must not be greater than 140 characters.'],
+                ],
+            ],
+            //            'Edge: 絵文字でも正しくカウントできる' => [
+            //                'data' => [
+            //                    'body' => str_repeat('🏴󠁧󠁢󠁥󠁮󠁧󠁿', 20),
+            //                ],
+            //                'errors' => [
+            //                    'body' => ['The body must not be greater than 140 characters.'],
+            //                ],
+            //            ],
+        ];
+    }
+}

--- a/packages/backend/tests/Unit/Requests/MessageCreateRequestTest.php
+++ b/packages/backend/tests/Unit/Requests/MessageCreateRequestTest.php
@@ -19,11 +19,6 @@ class MessageCreateRequestTest extends TestCase
         $this->request = new MessageCreateRequest();
     }
 
-    public function testInstanceOf(): void
-    {
-        $this->assertInstanceOf(MessageCreateRequest::class, $this->request);
-    }
-
     /**
      * バリデーションテスト
      *
@@ -31,16 +26,17 @@ class MessageCreateRequestTest extends TestCase
      *
      * @param  array  $data
      * @param  array  $errors
+     * @param  bool  $expect
      * @return void
      */
-    public function testSignupUsersArgsValidation(array $data, array $errors): void
+    public function testSignupUsersArgsValidation(array $data, array $errors, bool $expect): void
     {
         $rules = $this->request->rules();
         $validator = Validator::make($data, $rules);
 
         $result = $validator->passes();
 
-        $this->assertEquals(false, $result);
+        $this->assertEquals($expect, $result);
         $this->assertEquals($errors, $validator->errors()->toArray());
     }
 
@@ -50,11 +46,19 @@ class MessageCreateRequestTest extends TestCase
     public function signupUsersArgsValidationDataProvider(): array
     {
         return [
+            '正常系' => [
+                'data' => [
+                    'body' => 'test',
+                ],
+                'errors' => [],
+                'expect' => true,
+            ],
             'フィールドが空' => [
                 'data' => [],
                 'errors' => [
                     'body' => ['The body field is required.'],
                 ],
+                'expect' => false,
             ],
             '文字数が多すぎる' => [
                 'data' => [
@@ -63,6 +67,7 @@ class MessageCreateRequestTest extends TestCase
                 'errors' => [
                     'body' => ['The body must not be greater than 140 characters.'],
                 ],
+                'expect' => false,
             ],
             //            'Edge: 絵文字でも正しくカウントできる' => [
             //                'data' => [


### PR DESCRIPTION
# やったこと

- メッセージ投稿系テスト
  - メッセージ投稿
- リクエストテスト
  - MessageCreateRequestTest

# やらないこと

- なし

# できるようになること

- なし

# できなくなること

- なし

# 動作確認

- `make backend-test`

# レビュワーへの参考情報

- なし

# チェックリスト（全てにチェックを入れた上でレビュー依頼）

- [x] セルフレビューを行なった。
- [x] コメントが必要な箇所を洗い出し、書き残した。
- [x] 変更部分に対応するドキュメントを洗い出し、修正した。
- [x] 設計・コーディング規則に違反している箇所がないことを確認した。
- [x] スペルミスがないことを確認した。
